### PR TITLE
bugfix/build docs git add command order

### DIFF
--- a/lib/commands/build-docs.js
+++ b/lib/commands/build-docs.js
@@ -32,8 +32,8 @@ module.exports = {
     };
     const output = await jsdocToMd.render(cfg);
     await writeFile(readmePath, output, 'utf8');
-    await $`git add ./README.md`;
     const cli = path.relative(process.cwd(), path.resolve(__dirname, '../../bin/cli.js'));
     await $`${cli} prettier`;
+    await $`git add ./README.md`;
   }
 };


### PR DESCRIPTION
The command order for build-docs caused the `prettier` to run after we `git add ./README.md` our changes, meaning there would always be unstaged changes for README.md. This is simply fixed by running the `git add` command at the very end to stage and commit the changes from prettier as well.